### PR TITLE
remove image expiration from push CI

### DIFF
--- a/.tekton/rekor-monitor-push.yaml
+++ b/.tekton/rekor-monitor-push.yaml
@@ -24,8 +24,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/securesign/rekor-monitor:{{revision}}
-  - name: image-expires-after
-    value: 5d
   - name: dockerfile
     value: Dockerfile.rh
   - name: path-context


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Drop the 'image-expires-after' parameter from the .tekton/rekor-monitor-push.yaml configuration