### PR TITLE
update rekor_monitor: remove start/end index check

### DIFF
--- a/cmd/rekor_monitor/main.go
+++ b/cmd/rekor_monitor/main.go
@@ -191,13 +191,6 @@ func main() {
 			config.EndIndex = &checkpointEndIndex
 		}
 
-		if *config.StartIndex >= *config.EndIndex {
-			handleError(fmt.Sprintf("start index %d must be strictly less than end index %d", *config.StartIndex, *config.EndIndex), nil)
-			if !*once {
-				goto waitForTick
-			}
-		}
-
 		if identity.MonitoredValuesExist(monitoredValues) {
 			_, err = rekor.IdentitySearch(*config.StartIndex, *config.EndIndex, rekorClient, monitoredValues, config.OutputIdentitiesFile, config.IdentityMetadataFile)
 			if err != nil {


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Remove start/end index guard in rekor_monitor