### PR TITLE
fix: allow start > end as valid error in rekor_monitor

### DIFF
--- a/cmd/rekor_monitor/main.go
+++ b/cmd/rekor_monitor/main.go
@@ -191,6 +191,13 @@ func main() {
 			config.EndIndex = &checkpointEndIndex
 		}
 
+		if *config.StartIndex > *config.EndIndex {
+			handleError(fmt.Sprintf("start index %d must be less than or equal to end index %d", *config.StartIndex, *config.EndIndex), nil)
+			if !*once {
+				goto waitForTick
+			}
+		}
+
 		if identity.MonitoredValuesExist(monitoredValues) {
 			_, err = rekor.IdentitySearch(*config.StartIndex, *config.EndIndex, rekorClient, monitoredValues, config.OutputIdentitiesFile, config.IdentityMetadataFile)
 			if err != nil {

--- a/pkg/rekor/client.go
+++ b/pkg/rekor/client.go
@@ -64,11 +64,6 @@ func GetEntriesByIndexRange(ctx context.Context, rekorClient *client.Rekor, star
 		return nil, fmt.Errorf("start (%d) must be less than or equal to end (%d)", start, end)
 	}
 
-	// handle case where we initialize log monitor
-	if start == end {
-		start--
-	}
-
 	var logEntries []models.LogEntry
 	for i := start + 1; i <= end; i += 10 {
 		var logIndices []*int64

--- a/pkg/rekor/client_test.go
+++ b/pkg/rekor/client_test.go
@@ -115,11 +115,8 @@ func TestGetEntriesByIndexRange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error getting entries: %v", err)
 	}
-	if len(result) != 1 {
-		t.Fatalf("expected 1 entry, got %d", len(result))
-	}
-	if !reflect.DeepEqual(result[0], *logEntries[42]) {
-		t.Fatalf("entries should be equal for index 0, log index 42")
+	if len(result) != 0 {
+		t.Fatalf("expected 0 entries, got %d", len(result))
 	}
 
 	// failure: start greater than end


### PR DESCRIPTION
## Summary by Sourcery

Validate index bounds in rekor_monitor by erroring on start > end and remove the client-side fallback for equal start and end indices

Bug Fixes:
- Log an error and skip processing when monitor start index exceeds end index

Enhancements:
- Remove special-case decrement for start == end in GetEntriesByIndexRange