### PR TITLE
 [SECURESIGN-2745] add truncate & fork test

### DIFF
--- a/test/integration/monitor_tampered_test.go
+++ b/test/integration/monitor_tampered_test.go
@@ -1,66 +1,20 @@
 package integration
 
 import (
-	"os"
-	"strings"
 	"testing"
 )
 
-// tamperCheckpointRootHash reads a checkpoint file, tampers with its root hash,
-// and writes the modified content back to the file.
+// tamperCheckpointRootHash modifies a checkpoint file by appending "tampered" to its root hash
+// to simulate a corrupted checkpoint.
 //
-// The function performs the following steps:
-//  1. Reads the checkpoint file content.
-//  2. Preserves trailing newline and escaped newline ("\\n") if present.
-//  3. Splits the content into lines using "\\n" as the delimiter, expecting at least 3 lines
-//     (based on the checkpoint file format: tree ID, tree size, root hash, and optional signature).
-//     The SplitN function uses 4 as the maximum number of splits to ensure the signature (if present)
-//     is captured as a single line, even if it contains additional "\\n" separators.
-//  4. Modifies the root hash (line 3) by appending "tampered" to simulate a corrupted checkpoint.
-//  5. Reconstructs the content with the original trailing newline and escaped newline properties.
-//  6. Writes the tampered content back to the file with 0644 permissions.
-//
-// The number 4 in SplitN is chosen to accommodate the expected checkpoint file format:
-//   - Line 1: Tree ID
-//   - Line 2: Tree size
-//   - Line 3: Root hash
-//   - Line 4+: Optional signature or additional data
-//
-// By limiting to 4 splits, we ensure the signature (which may contain "\\n") is not split further.
+// It uses modifyCheckpointFile to handle the file operations, passing a function that
+// changes the root hash (third line) of the checkpoint.
 func tamperCheckpointRootHash(t *testing.T, checkpointFile string) {
 	t.Helper()
 
-	content, err := os.ReadFile(checkpointFile)
-	if err != nil {
-		t.Fatalf("failed to read checkpoint file: %v", err)
-	}
-
-	contentStr := string(content)
-	wasNewlineTrailing := strings.HasSuffix(contentStr, "\n")
-	contentStr = strings.TrimSuffix(contentStr, "\n")
-	wasEscapedTrailing := strings.HasSuffix(contentStr, "\\n")
-	contentStr = strings.TrimSuffix(contentStr, "\\n")
-
-	lines := strings.SplitN(contentStr, "\\n", 4)
-	if len(lines) < 3 {
-		t.Fatalf("invalid checkpoint file format: expected at least 3 lines, got %d", len(lines))
-	}
-
-	lines[2] = lines[2] + "tampered"
-
-	tamperedContent := strings.Join(lines, "\\n")
-	if wasEscapedTrailing {
-		tamperedContent += "\\n"
-	}
-
-	tamperedBytes := []byte(tamperedContent)
-	if wasNewlineTrailing {
-		tamperedBytes = append(tamperedBytes, '\n')
-	}
-
-	if err := os.WriteFile(checkpointFile, tamperedBytes, 0644); err != nil {
-		t.Fatalf("failed to write tampered checkpoint: %v", err)
-	}
+	modifyCheckpointFile(t, checkpointFile, func(lines []string) {
+		lines[2] = lines[2] + "tampered"
+	})
 }
 
 func TestTamperedCheckpoint(t *testing.T) {

--- a/test/integration/monitor_tampered_test.go
+++ b/test/integration/monitor_tampered_test.go
@@ -1,0 +1,85 @@
+package integration
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// tamperCheckpointRootHash reads a checkpoint file, tampers with its root hash,
+// and writes the modified content back to the file.
+//
+// The function performs the following steps:
+//  1. Reads the checkpoint file content.
+//  2. Preserves trailing newline and escaped newline ("\\n") if present.
+//  3. Splits the content into lines using "\\n" as the delimiter, expecting at least 3 lines
+//     (based on the checkpoint file format: tree ID, tree size, root hash, and optional signature).
+//     The SplitN function uses 4 as the maximum number of splits to ensure the signature (if present)
+//     is captured as a single line, even if it contains additional "\\n" separators.
+//  4. Modifies the root hash (line 3) by appending "tampered" to simulate a corrupted checkpoint.
+//  5. Reconstructs the content with the original trailing newline and escaped newline properties.
+//  6. Writes the tampered content back to the file with 0644 permissions.
+//
+// The number 4 in SplitN is chosen to accommodate the expected checkpoint file format:
+//   - Line 1: Tree ID
+//   - Line 2: Tree size
+//   - Line 3: Root hash
+//   - Line 4+: Optional signature or additional data
+//
+// By limiting to 4 splits, we ensure the signature (which may contain "\\n") is not split further.
+func tamperCheckpointRootHash(t *testing.T, checkpointFile string) {
+	t.Helper()
+
+	content, err := os.ReadFile(checkpointFile)
+	if err != nil {
+		t.Fatalf("failed to read checkpoint file: %v", err)
+	}
+
+	contentStr := string(content)
+	wasNewlineTrailing := strings.HasSuffix(contentStr, "\n")
+	contentStr = strings.TrimSuffix(contentStr, "\n")
+	wasEscapedTrailing := strings.HasSuffix(contentStr, "\\n")
+	contentStr = strings.TrimSuffix(contentStr, "\\n")
+
+	lines := strings.SplitN(contentStr, "\\n", 4)
+	if len(lines) < 3 {
+		t.Fatalf("invalid checkpoint file format: expected at least 3 lines, got %d", len(lines))
+	}
+
+	lines[2] = lines[2] + "tampered"
+
+	tamperedContent := strings.Join(lines, "\\n")
+	if wasEscapedTrailing {
+		tamperedContent += "\\n"
+	}
+
+	tamperedBytes := []byte(tamperedContent)
+	if wasNewlineTrailing {
+		tamperedBytes = append(tamperedBytes, '\n')
+	}
+
+	if err := os.WriteFile(checkpointFile, tamperedBytes, 0644); err != nil {
+		t.Fatalf("failed to write tampered checkpoint: %v", err)
+	}
+}
+
+func TestTamperedCheckpoint(t *testing.T) {
+	ctx, binary, checkpointFile, monitorPort, mockServer := setupTest(t)
+	defer mockServer.Close()
+
+	t.Run("validate_and_tamper_checkpoint_file", func(t *testing.T) {
+		tamperCheckpointRootHash(t, checkpointFile)
+	})
+
+	runCmd, logs := startMonitor(t, ctx, binary, checkpointFile, monitorPort, mockServer)
+
+	metrics := fetchMetrics(t, monitorPort)
+	validateLogsAndMetrics(t, logs, metrics, MonitorExpectations{
+		ExpectErrorLog:       true,
+		ExpectedErrorType:    "error running consistency check",
+		ExpectedFailureCount: 1,
+		ExpectedTotalCount:   1,
+	})
+
+	stopMonitor(t, runCmd)
+}

--- a/test/integration/monitor_truncation_forking_test.go
+++ b/test/integration/monitor_truncation_forking_test.go
@@ -2,85 +2,36 @@ package integration
 
 import (
 	"fmt"
-	"os"
 	"strconv"
-	"strings"
 	"testing"
 )
 
-// truncateAndForkCheckpointFile reads a checkpoint file, truncates its tree size, forks its root hash,
-// and writes the modified content back to the file.
+// truncateAndForkCheckpointFile modifies a checkpoint file by reducing its tree size and
+// appending "forked" to its root hash to simulate a log truncation and fork.
 //
-// The function performs the following steps:
-//  1. Reads the checkpoint file content.
-//  2. Preserves trailing newline and escaped newline ("\\n") if present.
-//  3. Splits the content into lines using "\\n" as the delimiter, expecting at least 3 lines
-//     (based on the checkpoint file format: tree ID, tree size, root hash, and optional signature).
-//     The SplitN function uses 4 as the maximum number of splits to ensure the signature (if present)
-//     is captured as a single line, even if it contains additional "\\n" separators.
-//  4. Truncates the tree size (line 2) by reducing it by 10 if it's greater than 10, or setting it to 1 otherwise,
-//     to simulate a log truncation.
-//  5. Forks the root hash (line 3) by appending "forked" to simulate a log fork.
-//  6. Reconstructs the content with the original trailing newline and escaped newline properties.
-//  7. Writes the modified content back to the file with 0644 permissions.
-//
-// The number 4 in SplitN is chosen to accommodate the expected checkpoint file format:
-//   - Line 1: Tree ID
-//   - Line 2: Tree size
-//   - Line 3: Root hash
-//   - Line 4+: Optional signature or additional data
-//
-// By limiting to 4 splits, we ensure the signature (which may contain "\\n") is not split further.
-// The number 10 for tree size reduction is chosen to simulate a significant truncation while
-// ensuring the resulting tree size remains positive.
+// It uses modifyCheckpointFile to handle the file operations, passing a function that:
+// - Reduces the tree size (second line) by 10 if it's greater than 10, or sets it to 1 otherwise.
+// - Appends "forked" to the root hash (third line).
 func truncateAndForkCheckpointFile(t *testing.T, checkpointFile string) {
 	t.Helper()
 
-	content, err := os.ReadFile(checkpointFile)
-	if err != nil {
-		t.Fatalf("failed to read checkpoint file: %v", err)
-	}
+	modifyCheckpointFile(t, checkpointFile, func(lines []string) {
+		treeSizeLine := lines[1]
+		rootHashLine := lines[2]
 
-	contentStr := string(content)
-	wasNewlineTrailing := strings.HasSuffix(contentStr, "\n")
-	contentStr = strings.TrimSuffix(contentStr, "\n")
-	wasEscapedTrailing := strings.HasSuffix(contentStr, "\\n")
-	contentStr = strings.TrimSuffix(contentStr, "\\n")
+		// Truncate: decrease the tree size
+		newTreeSize := "0"
+		if n, err := strconv.Atoi(treeSizeLine); err == nil && n > 10 {
+			newTreeSize = fmt.Sprintf("%d", n-10)
+		} else if err == nil {
+			newTreeSize = "1"
+		}
+		// Fork: alter the root hash
+		newRootHash := rootHashLine + "forked"
 
-	lines := strings.SplitN(contentStr, "\\n", 4)
-	if len(lines) < 3 {
-		t.Fatalf("invalid checkpoint file format: expected at least 3 lines, got %d", len(lines))
-	}
-
-	treeSizeLine := lines[1]
-	rootHashLine := lines[2]
-
-	// Truncate: decrease the tree size
-	newTreeSize := "0"
-	if n, err := strconv.Atoi(treeSizeLine); err == nil && n > 10 {
-		newTreeSize = fmt.Sprintf("%d", n-10)
-	} else if err == nil {
-		newTreeSize = "1"
-	}
-	// Fork: alter the root hash
-	newRootHash := rootHashLine + "forked"
-
-	lines[1] = newTreeSize
-	lines[2] = newRootHash
-
-	modifiedContent := strings.Join(lines, "\\n")
-	if wasEscapedTrailing {
-		modifiedContent += "\\n"
-	}
-
-	modifiedBytes := []byte(modifiedContent)
-	if wasNewlineTrailing {
-		modifiedBytes = append(modifiedBytes, '\n')
-	}
-
-	if err := os.WriteFile(checkpointFile, modifiedBytes, 0644); err != nil {
-		t.Fatalf("failed to write modified checkpoint: %v", err)
-	}
+		lines[1] = newTreeSize
+		lines[2] = newRootHash
+	})
 }
 
 func TestLogTruncationForking(t *testing.T) {

--- a/test/integration/monitor_truncation_forking_test.go
+++ b/test/integration/monitor_truncation_forking_test.go
@@ -1,0 +1,105 @@
+package integration
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// truncateAndForkCheckpointFile reads a checkpoint file, truncates its tree size, forks its root hash,
+// and writes the modified content back to the file.
+//
+// The function performs the following steps:
+//  1. Reads the checkpoint file content.
+//  2. Preserves trailing newline and escaped newline ("\\n") if present.
+//  3. Splits the content into lines using "\\n" as the delimiter, expecting at least 3 lines
+//     (based on the checkpoint file format: tree ID, tree size, root hash, and optional signature).
+//     The SplitN function uses 4 as the maximum number of splits to ensure the signature (if present)
+//     is captured as a single line, even if it contains additional "\\n" separators.
+//  4. Truncates the tree size (line 2) by reducing it by 10 if it's greater than 10, or setting it to 1 otherwise,
+//     to simulate a log truncation.
+//  5. Forks the root hash (line 3) by appending "forked" to simulate a log fork.
+//  6. Reconstructs the content with the original trailing newline and escaped newline properties.
+//  7. Writes the modified content back to the file with 0644 permissions.
+//
+// The number 4 in SplitN is chosen to accommodate the expected checkpoint file format:
+//   - Line 1: Tree ID
+//   - Line 2: Tree size
+//   - Line 3: Root hash
+//   - Line 4+: Optional signature or additional data
+//
+// By limiting to 4 splits, we ensure the signature (which may contain "\\n") is not split further.
+// The number 10 for tree size reduction is chosen to simulate a significant truncation while
+// ensuring the resulting tree size remains positive.
+func truncateAndForkCheckpointFile(t *testing.T, checkpointFile string) {
+	t.Helper()
+
+	content, err := os.ReadFile(checkpointFile)
+	if err != nil {
+		t.Fatalf("failed to read checkpoint file: %v", err)
+	}
+
+	contentStr := string(content)
+	wasNewlineTrailing := strings.HasSuffix(contentStr, "\n")
+	contentStr = strings.TrimSuffix(contentStr, "\n")
+	wasEscapedTrailing := strings.HasSuffix(contentStr, "\\n")
+	contentStr = strings.TrimSuffix(contentStr, "\\n")
+
+	lines := strings.SplitN(contentStr, "\\n", 4)
+	if len(lines) < 3 {
+		t.Fatalf("invalid checkpoint file format: expected at least 3 lines, got %d", len(lines))
+	}
+
+	treeSizeLine := lines[1]
+	rootHashLine := lines[2]
+
+	// Truncate: decrease the tree size
+	newTreeSize := "0"
+	if n, err := strconv.Atoi(treeSizeLine); err == nil && n > 10 {
+		newTreeSize = fmt.Sprintf("%d", n-10)
+	} else if err == nil {
+		newTreeSize = "1"
+	}
+	// Fork: alter the root hash
+	newRootHash := rootHashLine + "forked"
+
+	lines[1] = newTreeSize
+	lines[2] = newRootHash
+
+	modifiedContent := strings.Join(lines, "\\n")
+	if wasEscapedTrailing {
+		modifiedContent += "\\n"
+	}
+
+	modifiedBytes := []byte(modifiedContent)
+	if wasNewlineTrailing {
+		modifiedBytes = append(modifiedBytes, '\n')
+	}
+
+	if err := os.WriteFile(checkpointFile, modifiedBytes, 0644); err != nil {
+		t.Fatalf("failed to write modified checkpoint: %v", err)
+	}
+}
+
+func TestLogTruncationForking(t *testing.T) {
+	ctx, binary, checkpointFile, monitorPort, mockServer := setupTest(t)
+	defer mockServer.Close()
+
+	t.Run("truncate_fork_checkpoint_file", func(t *testing.T) {
+		truncateAndForkCheckpointFile(t, checkpointFile)
+	})
+
+	runCmd, logs := startMonitor(t, ctx, binary, checkpointFile, monitorPort, mockServer)
+
+	metrics := fetchMetrics(t, monitorPort)
+	validateLogsAndMetrics(t, logs, metrics, MonitorExpectations{
+		ExpectErrorLog:       true,
+		ExpectedErrorType:    "error running consistency check",
+		ExpectedFailureCount: 1,
+		ExpectedTotalCount:   1,
+	})
+
+	stopMonitor(t, runCmd)
+}

--- a/test/integration/monitor_valid_test.go
+++ b/test/integration/monitor_valid_test.go
@@ -1,0 +1,31 @@
+package integration
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMonitorWithValidCheckpoint(t *testing.T) {
+	ctx, binary, checkpointFile, monitorPort, mockServer := setupTest(t)
+	defer mockServer.Close()
+
+	runCmd, logs := startMonitor(t, ctx, binary, checkpointFile, monitorPort, mockServer)
+
+	metrics := fetchMetrics(t, monitorPort)
+	validateLogsAndMetrics(t, logs, metrics, MonitorExpectations{
+		ExpectErrorLog:       false,
+		ExpectedFailureCount: 0,
+		ExpectedTotalCount:   1,
+	})
+
+	time.Sleep(1 * time.Second)
+
+	metrics = fetchMetrics(t, monitorPort)
+	validateLogsAndMetrics(t, logs, metrics, MonitorExpectations{
+		ExpectErrorLog:       false,
+		ExpectedFailureCount: 0,
+		ExpectedTotalCount:   2,
+	})
+
+	stopMonitor(t, runCmd)
+}

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -19,141 +18,9 @@ import (
 
 type MonitorExpectations struct {
 	ExpectErrorLog       bool
+	ExpectedErrorType    string
 	ExpectedFailureCount int
 	ExpectedTotalCount   int
-}
-
-func TestMonitorWithValidCheckpoint(t *testing.T) {
-	ctx, binary, checkpointFile, monitorPort, mockServer := setupTest(t)
-	defer mockServer.Close()
-
-	runCmd, logs := startMonitor(t, ctx, binary, checkpointFile, monitorPort, mockServer)
-
-	metrics := fetchMetrics(t, monitorPort)
-	validateLogsAndMetrics(t, logs, metrics, MonitorExpectations{
-		ExpectErrorLog:       false,
-		ExpectedFailureCount: 0,
-		ExpectedTotalCount:   1,
-	})
-
-	time.Sleep(1 * time.Second)
-
-	metrics = fetchMetrics(t, monitorPort)
-	validateLogsAndMetrics(t, logs, metrics, MonitorExpectations{
-		ExpectErrorLog:       false,
-		ExpectedFailureCount: 0,
-		ExpectedTotalCount:   2,
-	})
-
-	stopMonitor(t, runCmd)
-}
-
-func TestTamperedCheckpoint(t *testing.T) {
-	ctx, binary, checkpointFile, monitorPort, mockServer := setupTest(t)
-	defer mockServer.Close()
-
-	t.Run("validate_and_tamper_checkpoint_file", func(t *testing.T) {
-		content, err := os.ReadFile(checkpointFile)
-		if err != nil {
-			t.Fatalf("failed to read checkpoint file: %v", err)
-		}
-		contentStr := string(content)
-		wasNewlineTrailing := strings.HasSuffix(contentStr, "\n")
-		contentStr = strings.TrimSuffix(contentStr, "\n")
-		wasEscapedTrailing := strings.HasSuffix(contentStr, "\\n")
-		contentStr = strings.TrimSuffix(contentStr, "\\n")
-		lines := strings.SplitN(contentStr, "\\n", 4)
-		if len(lines) < 3 {
-			t.Fatalf("invalid checkpoint file format: expected at least 3 lines, got %d", len(lines))
-		}
-		lines[2] = lines[2] + "tampered"
-		tamperedContent := strings.Join(lines, "\\n")
-		if wasEscapedTrailing {
-			tamperedContent += "\\n"
-		}
-		tamperedBytes := []byte(tamperedContent)
-		if wasNewlineTrailing {
-			tamperedBytes = append(tamperedBytes, '\n')
-		}
-		if err := os.WriteFile(checkpointFile, tamperedBytes, 0644); err != nil {
-			t.Fatalf("failed to write tampered checkpoint: %v", err)
-		}
-	})
-
-	runCmd, logs := startMonitor(t, ctx, binary, checkpointFile, monitorPort, mockServer)
-
-	metrics := fetchMetrics(t, monitorPort)
-	validateLogsAndMetrics(t, logs, metrics, MonitorExpectations{
-		ExpectErrorLog:       true,
-		ExpectedFailureCount: 1,
-		ExpectedTotalCount:   1,
-	})
-
-	stopMonitor(t, runCmd)
-}
-
-func TestLogTruncationForking(t *testing.T) {
-	ctx, binary, checkpointFile, monitorPort, mockServer := setupTest(t)
-	defer mockServer.Close()
-
-	t.Run("truncate_fork_checkpoint_file", func(t *testing.T) {
-		content, err := os.ReadFile(checkpointFile)
-		if err != nil {
-			t.Fatalf("failed to read checkpoint file: %v", err)
-		}
-
-		contentStr := string(content)
-		wasNewlineTrailing := strings.HasSuffix(contentStr, "\n")
-		contentStr = strings.TrimSuffix(contentStr, "\n")
-		wasEscapedTrailing := strings.HasSuffix(contentStr, "\\n")
-		contentStr = strings.TrimSuffix(contentStr, "\\n")
-
-		lines := strings.SplitN(contentStr, "\\n", 4)
-		if len(lines) < 3 {
-			t.Fatalf("invalid checkpoint file format: expected at least 3 lines, got %d", len(lines))
-		}
-
-		treeSizeLine := lines[1]
-		rootHashLine := lines[2]
-
-		// Truncate: decrease the tree size
-		newTreeSize := "0"
-		if n, err := strconv.Atoi(treeSizeLine); err == nil && n > 10 {
-			newTreeSize = fmt.Sprintf("%d", n-10)
-		} else if err == nil {
-			newTreeSize = "1"
-		}
-		// Fork: alter the root hash
-		newRootHash := rootHashLine + "forked"
-
-		lines[1] = newTreeSize
-		lines[2] = newRootHash
-
-		tamperedContent := strings.Join(lines, "\\n")
-		if wasEscapedTrailing {
-			tamperedContent += "\\n"
-		}
-
-		tamperedBytes := []byte(tamperedContent)
-		if wasNewlineTrailing {
-			tamperedBytes = append(tamperedBytes, '\n')
-		}
-
-		if err := os.WriteFile(checkpointFile, tamperedBytes, 0644); err != nil {
-			t.Fatalf("failed to write tampered checkpoint: %v", err)
-		}
-	})
-
-	runCmd, logs := startMonitor(t, ctx, binary, checkpointFile, monitorPort, mockServer)
-
-	metrics := fetchMetrics(t, monitorPort)
-	validateLogsAndMetrics(t, logs, metrics, MonitorExpectations{
-		ExpectErrorLog:       true,
-		ExpectedFailureCount: 1,
-		ExpectedTotalCount:   1,
-	})
-
-	stopMonitor(t, runCmd)
 }
 
 // setupTest prepares the test environment: builds the binary, initializes the checkpoint file,
@@ -285,6 +152,9 @@ func validateLogsAndMetrics(t *testing.T, logs *strings.Builder, metricsStr stri
 		if exp.ExpectErrorLog {
 			if !strings.Contains(logs.String(), "error running consistency check") {
 				t.Errorf("expected error log not found:\n%s", logs.String())
+			}
+			if exp.ExpectedErrorType != "" && !strings.Contains(logs.String(), exp.ExpectedErrorType) {
+				t.Errorf("expected error type '%s' not found in logs:\n%s", exp.ExpectedErrorType, logs.String())
 			}
 		} else {
 			if strings.Contains(logs.String(), "error") {

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -224,3 +224,65 @@ kBbmLSGtks4L3qX6yYY0zufBnhC8Ur/iy55GhWP/9A/bY2LhC30M9+RYtw==
 
 	return httptest.NewServer(handler)
 }
+
+// modifyCheckpointFile reads a checkpoint file, applies modifications via a callback function,
+// and writes the modified content back to the file.
+//
+// Parameters:
+//   - t: The testing object for error reporting.
+//   - checkpointFile: The path to the checkpoint file to modify.
+//   - modify: A callback function that applies changes to the parsed lines.
+//
+// The function performs the following steps:
+//  1. Reads the checkpoint file content.
+//  2. Preserves trailing newline and escaped newline ("\\n") if present.
+//  3. Splits the content into lines using "\\n" as the delimiter, expecting at least 3 lines
+//     (based on the checkpoint file format: tree ID, tree size, root hash, and optional signature).
+//     The SplitN function uses 4 as the maximum number of splits to ensure the signature (if present)
+//     is captured as a single line, even if it contains additional "\\n" separators.
+//  4. Calls the provided callback function to modify the lines (e.g., altering the tree size or root hash).
+//  5. Reconstructs the content with the original trailing newline and escaped newline properties.
+//  6. Writes the modified content back to the file with 0644 permissions.
+//
+// The number 4 in SplitN is chosen to accommodate the expected checkpoint file format:
+//   - Line 1: Tree ID
+//   - Line 2: Tree size
+//   - Line 3: Root hash
+//   - Line 4+: Optional signature or additional data
+//
+// By limiting to 4 splits, we ensure the signature (which may contain "\\n") is not split further.
+func modifyCheckpointFile(t *testing.T, checkpointFile string, modify func(lines []string)) {
+	t.Helper()
+
+	content, err := os.ReadFile(checkpointFile)
+	if err != nil {
+		t.Fatalf("failed to read checkpoint file: %v", err)
+	}
+
+	contentStr := string(content)
+	wasNewlineTrailing := strings.HasSuffix(contentStr, "\n")
+	contentStr = strings.TrimSuffix(contentStr, "\n")
+	wasEscapedTrailing := strings.HasSuffix(contentStr, "\\n")
+	contentStr = strings.TrimSuffix(contentStr, "\\n")
+
+	lines := strings.SplitN(contentStr, "\\n", 4)
+	if len(lines) < 3 {
+		t.Fatalf("invalid checkpoint file format: expected at least 3 lines, got %d", len(lines))
+	}
+
+	modify(lines)
+
+	modifiedContent := strings.Join(lines, "\\n")
+	if wasEscapedTrailing {
+		modifiedContent += "\\n"
+	}
+
+	modifiedBytes := []byte(modifiedContent)
+	if wasNewlineTrailing {
+		modifiedBytes = append(modifiedBytes, '\n')
+	}
+
+	if err := os.WriteFile(checkpointFile, modifiedBytes, 0644); err != nil {
+		t.Fatalf("failed to write modified checkpoint: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Add TestLogTruncationForking integration test to simulate and detect checkpoint file truncation and fork scenarios