### PR TITLE
[SECURESIGN-2747] add test with empty Rekor log

### DIFF
--- a/test/integration/monitor_basic_test.go
+++ b/test/integration/monitor_basic_test.go
@@ -32,7 +32,7 @@ func TestMonitorWithValidCheckpoint(t *testing.T) {
 }
 
 func TestMonitorWithEmptyLog(t *testing.T) {
-	emptyMockServer := RekorServer().WithEmptyData().Build()
+	emptyMockServer := RekorServer().Build()
 	ctx, binary, checkpointFile, monitorPort := setupTest(t, emptyMockServer)
 	defer emptyMockServer.Close()
 

--- a/test/integration/monitor_tampered_test.go
+++ b/test/integration/monitor_tampered_test.go
@@ -18,7 +18,8 @@ func tamperCheckpointRootHash(t *testing.T, checkpointFile string) {
 }
 
 func TestTamperedCheckpoint(t *testing.T) {
-	ctx, binary, checkpointFile, monitorPort, mockServer := setupTest(t)
+	mockServer := RekorServer().WithData().Build()
+	ctx, binary, checkpointFile, monitorPort := setupTest(t, mockServer)
 	defer mockServer.Close()
 
 	t.Run("validate_and_tamper_checkpoint_file", func(t *testing.T) {

--- a/test/integration/monitor_truncation_forking_test.go
+++ b/test/integration/monitor_truncation_forking_test.go
@@ -35,7 +35,8 @@ func truncateAndForkCheckpointFile(t *testing.T, checkpointFile string) {
 }
 
 func TestLogTruncationForking(t *testing.T) {
-	ctx, binary, checkpointFile, monitorPort, mockServer := setupTest(t)
+	mockServer := RekorServer().WithData().Build()
+	ctx, binary, checkpointFile, monitorPort := setupTest(t, mockServer)
 	defer mockServer.Close()
 
 	t.Run("truncate_fork_checkpoint_file", func(t *testing.T) {

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -29,9 +29,20 @@ type RekorServerBuilder struct {
 	logJSON   string
 }
 
-// RekorServer returns a new builder with defaults.
+// RekorServer returns a new builder preconfigured with an empty log.
 func RekorServer() *RekorServerBuilder {
-	return &RekorServerBuilder{}
+	return &RekorServerBuilder{
+		publicKey: `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFSHl2cMn87xLeZuOo0q3tGgdj8+y
+x1SXoyVJNLAXZiYXCdPm7+DULIZXyKSSv6RS2emHrBbWtCrQtBaM3GxlMA==
+-----END PUBLIC KEY-----`,
+		logJSON: `{
+  "rootHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "signedTreeHead": "c45c80833111 - 2882947332475159079\n0\n47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=\n\n— c45c80833111 8YHtBzBFAiBOzlkS1nQNcmgd24f/gawQ/LRYyUh6NjO55Pn3PJTbZgIhAPyb+DCWdgFNqQVmVp8eBaSTrCwdICr09QMiNtyPgvGm\n",
+  "treeID": "2882947332475159079",
+  "treeSize": 0
+}`,
+	}
 }
 
 // setupTest prepares the test environment: builds the binary, initializes the checkpoint file,
@@ -207,22 +218,6 @@ func stopMonitor(t *testing.T, runCmd *exec.Cmd) {
 			}
 		}
 	})
-}
-
-// WithEmptyData configures the server to serve an empty log.
-func (b *RekorServerBuilder) WithEmptyData() *RekorServerBuilder {
-	b.publicKey = `-----BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFSHl2cMn87xLeZuOo0q3tGgdj8+y
-x1SXoyVJNLAXZiYXCdPm7+DULIZXyKSSv6RS2emHrBbWtCrQtBaM3GxlMA==
------END PUBLIC KEY-----`
-
-	b.logJSON = `{
-  "rootHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "signedTreeHead": "c45c80833111 - 2882947332475159079\n0\n47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=\n\n— c45c80833111 8YHtBzBFAiBOzlkS1nQNcmgd24f/gawQ/LRYyUh6NjO55Pn3PJTbZgIhAPyb+DCWdgFNqQVmVp8eBaSTrCwdICr09QMiNtyPgvGm\n",
-  "treeID": "2882947332475159079",
-  "treeSize": 0
-}`
-	return b
 }
 
 // WithData configures the server to serve a non-empty log.


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new integration test for handling an empty Rekor log and refactor test setup to accept externally provided mock servers.

Enhancements:
- Refactor setupTest to accept a mockServer parameter and remove internal mock server initialization
- Update existing Rekor monitor tests to inject the mock server into setupTest

Tests:
- Add TestMonitorWithEmptyLog integration test to verify monitor behavior with an empty Rekor log
- Implement StartMockEmptyRekorServer helper for simulating an empty log