### PR TITLE
[SECURESIGN-2749] Test rekor monitor with high-frequency fetch intervals

### DIFF
--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 )
 
+const defaultInterval = "2s"
+
 var binaryPath string
 
 func TestMain(m *testing.M) {
@@ -84,10 +86,10 @@ func findFreePort() (int, error) {
 }
 
 // Start the monitor and return the Cmd and logs builder
-func startMonitorCommand(ctx context.Context, checkpointFile string, monitorPort int, serverUrl string) *exec.Cmd {
+func startMonitorCommand(ctx context.Context, checkpointFile string, monitorPort int, serverUrl string, interval string) *exec.Cmd {
 	return exec.CommandContext(ctx, binaryPath,
 		"--once=false",
-		"--interval=2s",
+		"--interval", interval,
 		"--file", checkpointFile,
 		"--url", serverUrl,
 		"--monitor-port", fmt.Sprintf("%d", monitorPort),

--- a/test/integration/monitor_basic_test.go
+++ b/test/integration/monitor_basic_test.go
@@ -17,7 +17,7 @@ func TestMonitorWithValidCheckpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to find free port: %v", err)
 	}
-	runCmd := startMonitorCommand(ctx, checkpointFile, monitorPort, mockServer.URL)
+	runCmd := startMonitorCommand(ctx, checkpointFile, monitorPort, mockServer.URL, defaultInterval)
 	logs := bytes.NewBuffer(nil)
 	runCmd.Stdout = logs
 	runCmd.Stderr = logs
@@ -63,7 +63,7 @@ func TestMonitorWithEmptyLog(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to find free port: %v", err)
 	}
-	runCmd := startMonitorCommand(ctx, checkpointFile, monitorPort, emptyMockServer.URL)
+	runCmd := startMonitorCommand(ctx, checkpointFile, monitorPort, emptyMockServer.URL, defaultInterval)
 	logs := bytes.NewBuffer(nil)
 	runCmd.Stdout = logs
 	runCmd.Stderr = logs
@@ -79,6 +79,51 @@ func TestMonitorWithEmptyLog(t *testing.T) {
 		ExpectErrorLog:       false,
 		ExpectedFailureCount: 0,
 		ExpectedTotalCount:   1,
+	})
+
+	cancel()
+	// Wait for the monitor to exit, test timeouts if it doesn't
+	runCmd.Wait()
+}
+
+func TestMonitorHighFrequencyFetch(t *testing.T) {
+	mockServer := RekorServer().WithData().Build()
+	defer mockServer.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	checkpointFile := createCheckpointFile(ctx, t, mockServer.URL, false)
+	monitorPort, err := findFreePort()
+	if err != nil {
+		t.Fatalf("failed to find free port: %v", err)
+	}
+
+	highFrequencyInterval := "500ms"
+	intervalDur, err := time.ParseDuration(highFrequencyInterval)
+	if err != nil {
+		t.Fatalf("invalid interval: %v", err)
+	}
+	testDuration := 3 * time.Second
+	expectedFetches := int(testDuration / intervalDur)
+
+	runCmd := startMonitorCommand(ctx, checkpointFile, monitorPort, mockServer.URL, highFrequencyInterval)
+	logs := bytes.NewBuffer(nil)
+	runCmd.Stdout = logs
+	runCmd.Stderr = logs
+	if err := runCmd.Start(); err != nil {
+		t.Fatalf("failed to start monitor: %v", err)
+	}
+
+	time.Sleep(testDuration)
+
+	metrics, err := fetchMetrics(monitorPort)
+	if err != nil {
+		t.Fatalf("failed to fetch metrics: %v", err)
+	}
+
+	validateLogsAndMetrics(t, logs, metrics, MonitorExpectations{
+		ExpectErrorLog:       false,
+		ExpectedFailureCount: 0,
+		ExpectedTotalCount:   expectedFetches,
 	})
 
 	cancel()

--- a/test/integration/monitor_tampered_test.go
+++ b/test/integration/monitor_tampered_test.go
@@ -33,7 +33,7 @@ func TestTamperedCheckpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to find free port: %v", err)
 	}
-	runCmd := startMonitorCommand(ctx, checkpointFile, monitorPort, mockServer.URL)
+	runCmd := startMonitorCommand(ctx, checkpointFile, monitorPort, mockServer.URL, defaultInterval)
 	logs := bytes.NewBuffer(nil)
 	runCmd.Stderr = logs
 	if err := runCmd.Start(); err != nil {

--- a/test/integration/monitor_truncation_forking_test.go
+++ b/test/integration/monitor_truncation_forking_test.go
@@ -51,7 +51,7 @@ func TestLogTruncationForking(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to find free port: %v", err)
 	}
-	runCmd := startMonitorCommand(ctx, checkpointFile, monitorPort, mockServer.URL)
+	runCmd := startMonitorCommand(ctx, checkpointFile, monitorPort, mockServer.URL, defaultInterval)
 	logs := bytes.NewBuffer(nil)
 	runCmd.Stderr = logs
 	if err := runCmd.Start(); err != nil {

--- a/test/integration/monitor_unavailable_log_server_test.go
+++ b/test/integration/monitor_unavailable_log_server_test.go
@@ -21,7 +21,7 @@ func TestMonitorWithUnavailableRekorServer(t *testing.T) {
 
 	var runCmd *exec.Cmd
 	t.Run("start_monitor", func(t *testing.T) {
-		runCmd = startMonitorCommand(ctx, checkpointFile, monitorPort, unavailableServer)
+		runCmd = startMonitorCommand(ctx, checkpointFile, monitorPort, unavailableServer, defaultInterval)
 	})
 
 	var outBuf bytes.Buffer


### PR DESCRIPTION
## Summary by Sourcery

Parameterize monitor fetch interval in integration tests and add a high-frequency fetch interval test

Enhancements:
- Update startMonitor helper to accept a custom fetch interval instead of a hardcoded value

Tests:
- Adjust existing integration tests to pass a 2s interval to startMonitor
- Add TestMonitorHighFrequencyFetch to validate monitor behavior with a 500ms fetch interval