### PR TITLE
Tdalton/trigger konflux addition

### DIFF
--- a/.github/workflows/trigger-konflux-build.yml
+++ b/.github/workflows/trigger-konflux-build.yml
@@ -1,0 +1,11 @@
+name: Trigger Konflux build
+on:
+  workflow_dispatch:
+
+jobs:
+  trigger-konflux-build:
+    uses: securesign/actions/.github/workflows/trigger-konflux-build.yaml@main
+    with:
+      branch: main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.tekton/rekor-monitor-pull-request.yaml
+++ b/.tekton/rekor-monitor-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"  &&
-      ( "Dockerfile.rh".pathChanged() || ".tekton/rekor-monitor-pull-request.yaml".pathChanged()|| "go.mod".pathChanged() || "go.sum".pathChanged() || "cmd/rekor_monitor/***".pathChanged() || "cmd/ct_monitor/***".pathChanged() || "pkg/***".pathChanged() || "Makefile".pathChanged() )
+      ( "Dockerfile.rh".pathChanged() || ".tekton/rekor-monitor-pull-request.yaml".pathChanged()|| "go.mod".pathChanged() || "go.sum".pathChanged() || "cmd/rekor_monitor/***".pathChanged() || "cmd/ct_monitor/***".pathChanged() || "pkg/***".pathChanged() || "Makefile".pathChanged()  || "trigger-konflux-builds.txt".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rekor-monitor

--- a/.tekton/rekor-monitor-push.yaml
+++ b/.tekton/rekor-monitor-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"  &&
-      ( "Dockerfile.rh".pathChanged() || ".tekton/rekor-monitor-push.yaml".pathChanged()|| "go.mod".pathChanged() || "go.sum".pathChanged() || "cmd/rekor_monitor/***".pathChanged() || "cmd/ct_monitor/***".pathChanged() || "pkg/***".pathChanged() || "Makefile".pathChanged() )
+      ( "Dockerfile.rh".pathChanged() || ".tekton/rekor-monitor-push.yaml".pathChanged()|| "go.mod".pathChanged() || "go.sum".pathChanged() || "cmd/rekor_monitor/***".pathChanged() || "cmd/ct_monitor/***".pathChanged() || "pkg/***".pathChanged() || "Makefile".pathChanged() || "trigger-konflux-builds.txt".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rekor-monitor


### PR DESCRIPTION
## Summary by Sourcery

Enable triggering Konflux builds by adding a dedicated file trigger and CI workflow

CI:
- Add a GitHub Actions workflow to manually dispatch Konflux builds
- Update Tekton monitor pipelines to trigger on changes to trigger-konflux-builds.txt