### PR TITLE
Update release-version to 1.3.5

### DIFF
--- a/.tekton/rekor-monitor-pull-request.yaml
+++ b/.tekton/rekor-monitor-pull-request.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.3.4
+    value: 1.3.5
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/rekor-monitor-push.yaml
+++ b/.tekton/rekor-monitor-push.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.3.4
+    value: 1.3.5
   - name: git-url
     value: '{{source_url}}'
   - name: revision


### PR DESCRIPTION
## Summary
- Update release-version parameter to 1.3.5 in Tekton pipeline files

## Test plan
- Verify Tekton pipelines run with version 1.3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)