### PR TITLE
ci: add Codecov OIDC auth and unit flag in separate coverage workflow

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -59,4 +59,5 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           use_oidc: true
+          flags: unit
           env_vars: OS

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -27,6 +27,7 @@ jobs:
     name: Check code coverage
     permissions:
       contents: read
+      id-token: write
     runs-on: ubuntu-latest
 
     env:
@@ -57,5 +58,5 @@ jobs:
       - name: Upload Coverage Report
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           env_vars: OS

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,17 +14,16 @@
 
 coverage:
   status:
-    # Patch coverage ensures new code changes are tested before merging
-    patch:
-      default:
-        target: 70%           # Require 70% of new code to be tested
-        threshold: 5%         # Allow variance of 5% (so 65%+ passes)
-        base: auto            # Compare against PR base
-
-    # Project coverage monitors overall codebase coverage trends
     project:
       default:
-        target: auto          # Use dynamic target based on parent commit
-        threshold: 5%         # Allow variance of 5%
-        base: auto
-        only_pulls: true      # Only check on pull requests
+        target: auto
+        informational: true
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+        informational: true
+
+flag_management:
+  default_rules:
+    carryforward: true


### PR DESCRIPTION
## Summary
- Add dedicated `code-coverage.yml` workflow for pull requests with OIDC authentication (`use_oidc: true`) and `unit` test flag for Codecov uploads
- Standardize `codecov.yml` to organizational guidelines
- Upstream `main.yml` CI workflow left untouched (disabled in this fork)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Based on the [doc](https://docs.google.com/document/d/1fJCU06XPVPEmD7abntayeyt2fTrMoWfLSss7Gf0sjnQ/edit?tab=t.0#heading=h.xoh1dhlzwjop)