### PR TITLE
fix: add push trigger to coverage workflow for Codecov baseline

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -16,6 +16,8 @@
 name: Code Coverage
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
## Summary
- Add `push` trigger on `main` branch to the coverage workflow
- Codecov needs at least one upload from `main` to establish a baseline for PR comparisons
- Without this, the Codecov dashboard shows "No data" for rekor-monitor

## Test plan
- [ ] After merge, verify coverage workflow runs on the merge commit
- [ ] Confirm Codecov dashboard shows non-zero coverage for rekor-monitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)