### PR TITLE
feat: approve Ed25519 in FIPS 140-3 key validation

### DIFF
--- a/pkg/util/fips.go
+++ b/pkg/util/fips.go
@@ -20,7 +20,6 @@ import (
 	"crypto/ed25519"
 	"crypto/fips140"
 	"crypto/rsa"
-	"errors"
 	"fmt"
 )
 
@@ -29,7 +28,7 @@ import (
 
 // ValidatePublicKey checks whether a crypto.PublicKey uses a FIPS-approved
 // algorithm. Returns nil when FIPS mode is disabled or when the key is approved.
-// Approved: RSA (>= 2048-bit), ECDSA. Rejected: Ed25519, RSA < 2048-bit, all others.
+// Approved: RSA (>= 2048-bit), ECDSA, Ed25519. Rejected: RSA < 2048-bit, all others.
 func ValidatePublicKey(pub crypto.PublicKey) error {
 	if !fips140.Enabled() {
 		return nil
@@ -43,7 +42,7 @@ func ValidatePublicKey(pub crypto.PublicKey) error {
 	case *ecdsa.PublicKey:
 		return nil
 	case ed25519.PublicKey:
-		return errors.New("ed25519 is not supported in FIPS mode")
+		return nil
 	default:
 		return fmt.Errorf("unsupported key type %T in FIPS mode", pub)
 	}


### PR DESCRIPTION
## Summary
- Allow Ed25519 public keys in `ValidatePublicKey()` when FIPS mode is enabled
- Ed25519 (EdDSA) is FIPS-approved under FIPS 186-5 and implemented inside Go's native FIPS 140-3 Cryptographic Module (CAVP cert A6650), retroactive to `GOFIPS140=v1.0.0`
- Previously, the monitor would reject valid FIPS-compliant log entries and verifier keys that use Ed25519 signatures